### PR TITLE
whole contig debris + more

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ Usage:
 makeAgpFromFasta.py usage:	makeAgpFromFasta.py <fasta_file> <agp_out_file>
 ```
 
+### degap_assembly.py
+Some newer versions of juicebox may introduce gaps explicitly as contigs in the .assembly file. We are not currently supporting this in the `juicebox_assembly_converter.py` script, but we include the `degap_assembly.py` script which will remove the gap contigs and convert to an old-style .assembly file that our tools will accept. (Note that we already add gaps to scaffolds generated with `juicebox_assembly_converter.py`, which is why it fails.) This tool takes the .assembly file path as a positional argument and writes a new file to STDOUT:
+
+```
+python degap_assembly.py has_gaps.assembly > no_gaps.assembly
+```
+
 ## Example Workflows
 Here are some of the common tasks that one might want to use these scripts for.
 

--- a/juicebox_scripts/degap_assembly.py
+++ b/juicebox_scripts/degap_assembly.py
@@ -1,0 +1,18 @@
+#/usr/bin/env python
+
+from __future__ import print_function
+import sys
+
+with open(sys.argv[1]) as file:
+    gap_index = "not an index"
+    for line in file:
+        if line.startswith(">"):
+            if line.startswith(">hic_gap"):
+                gap_index = line.split()[1]
+                print("omitting entries with index {} as gaps".format(gap_index), file=sys.stderr)
+                continue
+            print(line.strip())
+        else:
+            fields = line.split()
+            degapped = [field for field in fields if field != gap_index]
+            print(" ".join(degapped))

--- a/tests/collateral/test_inputs/test_breaks_reordered_debris.assembly
+++ b/tests/collateral/test_inputs/test_breaks_reordered_debris.assembly
@@ -1,0 +1,23 @@
+>contig_1_len_29:::fragment_2:::debris 1 6
+>contig_1_len_29:::fragment_3 2 15
+>contig_2_len_1 3 2
+>contig_3_len_1 4 2
+>contig_4_len_20 5 21
+>contig_5_len_25 6 26
+>contig_1_len_29:::fragment_1 7 11
+>contig_6_len_26:::fragment_1 8 7
+>contig_6_len_26:::fragment_2:::debris 9 6
+>contig_6_len_26:::fragment_3 10 7
+>contig_6_len_26:::fragment_4:::debris 11 6
+>contig_6_len_26:::fragment_5 12 5
+>contig_7_len_25 13 26
+>contig_8_len_16 14 17
+>contig_9_len_64:::debris 15 65
+7 -3 4
+-2 5 9
+6 -8 -13
+10
+12 14
+-15
+1
+-11

--- a/tests/collateral/test_inputs/test_breaks_reordered_debris_bad.assembly
+++ b/tests/collateral/test_inputs/test_breaks_reordered_debris_bad.assembly
@@ -1,0 +1,23 @@
+>contig_1_len_29:::fragment_2:::debris 1 6
+>contig_1_len_29:::fragment_3 2 15
+>contig_2_len_1 3 2
+>contig_3_len_1 4 2
+>contig_4_len_20 5 21
+>contig_5_len_25 6 26
+>contig_1_len_29:::fragment_1 7 11
+>contig_6_len_26:::fragment_1 8 7
+>contig_6_len_26:::fragment_2:::debris 9 6
+>contig_6_len_26:::fragment_3 10 7
+>contig_6_len_26:::fragment_4:::debris 11 6
+>contig_6_len_26:::fragment_5 12 5
+>contig_7_len_25 13 26
+>contig_8_len_16 14 17
+>contig_9_len_64:::debris 15 1
+7 -3 4
+-2 5 9
+6 -8 -13
+10
+12 14
+-15
+1
+-11

--- a/tests/test_juicebox_assembly_converter.py
+++ b/tests/test_juicebox_assembly_converter.py
@@ -37,7 +37,7 @@ import unittest
 from juicebox_scripts.juicebox_assembly_converter import JuiceboxConverter, ProcessedAssembly
 
 from juicebox_scripts.juicebox_assembly_converter import InvalidFastaError, MissingFragmentError, \
-    UnscaffoldedContigError, ZeroLengthContigError
+    UnscaffoldedContigError, ZeroLengthContigError, BadContigNameError
 
 class JuiceboxConverterTestCase(unittest.TestCase):
     def setUp(self):
@@ -55,6 +55,7 @@ class JuiceboxConverterTestCase(unittest.TestCase):
         self.test_breaks_assembly = self.test_file_dir + 'test_breaks.assembly'
         self.test_breaks_oversize_fragment = self.test_file_dir + 'test_breaks_oversize_fragment.assembly'
         self.test_reordered_breaks_assembly = self.test_file_dir + 'test_breaks_reordered.assembly'
+        self.test_reordered_breaks_debris_assembly = self.test_file_dir + 'test_breaks_reordered_debris.assembly'
         self.test_contigs_bad_assembly = self.test_file_dir + 'test_contigs_bad.assembly'
         self.test_contigs_assembly = self.test_file_dir + 'test_contigs.assembly'
         self.test_scaffolds_bad_assembly = self.test_file_dir + 'test_scaffolds_bad.assembly'
@@ -121,6 +122,19 @@ class JuiceboxConverterTestCase(unittest.TestCase):
         self.assertEqual(breaks.fasta(), expected_breaks_fasta)
         self.assertEqual(breaks.agp(), expected_breaks_agp)
         self.assertEqual(breaks.bed(), expected_breaks_bed)
+
+    def test_make_breaks_debris(self):
+        breaks = self.converter.process(self.test_fasta, self.test_reordered_breaks_debris_assembly)
+        expected_breaks_fasta = self.read_file_lines(self.expected_result_breaks_fasta)
+        expected_breaks_agp = self.read_file_lines(self.expected_result_breaks_agp)
+        expected_breaks_bed = self.read_file_lines(self.expected_result_breaks_bed)
+        self.assertEqual(breaks.fasta(), expected_breaks_fasta)
+        self.assertEqual(breaks.agp(), expected_breaks_agp)
+        self.assertEqual(breaks.bed(), expected_breaks_bed)
+
+    def test_make_breaks_debris(self):
+        with self.assertRaises(BadContigNameError):
+            breaks = self.converter.process(self.test_fasta, self.test_reordered_breaks_debris_assembly)
 
     def test_make_contigs_in_contig_mode(self):
         contigs = self.converter.process(self.test_fasta, self.test_contigs_assembly, contig_mode=True)


### PR DESCRIPTION
user luciaalvarez95 found that new versions of juicebox _sometimes_ have a weird gapping format. In process of dealing with that (see new script, not bug-checked), also discovered that whole-contig debris causes the converter to choke, so I added some logic to handle that.

* added script to degap new juicebox output that we sometimes see
* added features to handle whole contigs put in debris
* added tests for whole contig debris situations